### PR TITLE
Added binding restore if layout restore happened

### DIFF
--- a/XamlDesigner/MainWindow.xaml.cs
+++ b/XamlDesigner/MainWindow.xaml.cs
@@ -151,10 +151,20 @@ namespace ICSharpCode.XamlDesigner
 			uxDockingManager.Loaded += delegate {
 				if (Settings.Default.AvalonDockLayout != null) {
 					uxDockingManager.RestoreLayout(Settings.Default.AvalonDockLayout.ToStream());
+					RestoreDocumentPaneBinding();
 				}
 			};
 		}
-
+		
+		private void RestoreDocumentPaneBinding()
+        	{
+            		uxDocumentPane = uxDockingManager.MainDocumentPane;
+            		uxDocumentPane.SetBinding(DocumentPane.SelectedValueProperty, "CurrentDocument");
+            		uxDocumentPane.SelectedValuePath = "DataContext";
+            		AvalonDockWorkaround();
+         
+        	}
+		
 		void SaveSettings()
 		{
 			Settings.Default.MainWindowState = WindowState;


### PR DESCRIPTION
Before restoring layout was dropping current layout settings such as bindings, and eventually document pane was not updating according to added new designers. I just added one method that re creates binding for document pane and calls AvalonDockWorkaround method