### PR TITLE
Changed OpenCommand_Executed

### DIFF
--- a/XamlDesigner/MainWindow_Commands.cs
+++ b/XamlDesigner/MainWindow_Commands.cs
@@ -39,6 +39,7 @@ namespace ICSharpCode.XamlDesigner
 		void OpenCommand_Executed(object sender, ExecutedRoutedEventArgs e)
 		{
 			Shell.Instance.Open();
+			AvalonDockWorkaround();
 		}
 
 		void CloseCommand_Executed(object sender, ExecutedRoutedEventArgs e)


### PR DESCRIPTION
Opening already added document does not bring it to document pane. I just call AvalonDockWorkaround() to re synchronize that document with document pane after opening document. If there is other workaround just undo this.