### PR TITLE
Removed code that toggles selection when controls are placed

### DIFF
--- a/WpfDesign.Designer/Project/Extensions/DefaultPlacementBehavior.cs
+++ b/WpfDesign.Designer/Project/Extensions/DefaultPlacementBehavior.cs
@@ -58,12 +58,6 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		public virtual void EndPlacement(PlacementOperation operation)
 		{
 			InfoTextEnterArea.Stop(ref infoTextEnterArea);
-
-			if (operation.Type != PlacementType.Delete)
-			{
-				this.ExtendedItem.Services.Selection.SetSelectedComponents(null);
-				this.ExtendedItem.Services.Selection.SetSelectedComponents(operation.PlacedItems.Select(x => x.Item).ToList());
-			}
 		}
 
 		public virtual Rect GetPosition(PlacementOperation operation, DesignItem item)


### PR DESCRIPTION
In DefaultPlacementBehavior - when ending a placement - the selection is first cleared, and then right after set back to the previously selected controls.

It does not seem correct that the selection is modified based on a placement. Also it can cause performance issues for extensions that are used to edit a control over a number of placement operations because the extension is removed and reapplied on every operation.

I suggest this code is removed.

If this is a trick to reapply extensions for the selected controls I think it should be handled in a way where the selection is not altered.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the WPF Designer open source product (the "Contribution"). My Contribution is licensed under the MIT License.