### PR TITLE
Fixed a bug for root nodes with namespace prefix

### DIFF
--- a/WpfDesign.XamlDom/Project/XamlDocument.cs
+++ b/WpfDesign.XamlDom/Project/XamlDocument.cs
@@ -285,7 +285,7 @@ namespace ICSharpCode.WpfDesign.XamlDom
 
 			string prefix = _xmlDoc.DocumentElement.GetPrefixOfNamespace(@namespace);
 
-			if (_xmlDoc.DocumentElement.NamespaceURI == @namespace && _xmlDoc.Prefix == String.Empty)
+			if (_xmlDoc.DocumentElement.NamespaceURI == @namespace && _xmlDoc.DocumentElement.Prefix == String.Empty)
 			{
 				return string.Empty;
 			}


### PR DESCRIPTION
This fixes a bug in XamlDocument when you have a DocumentElement which is not in the presentation namespace (http://schemas.microsoft.com/winfx/2006/xaml/presentation).

When inserting a new control with the same namespace as the DocumentElement, the GetPrefixForNamespace method would return an empty string. With this fix the correct prefix is now returned.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the WPF Designer open source product (the "Contribution"). My Contribution is licensed under the MIT License.