### PR TITLE
Fixed a bug where snaplines were not applied to all items

### DIFF
--- a/WpfDesign.Designer/Project/Extensions/SnaplinePlacementBehavior.cs
+++ b/WpfDesign.Designer/Project/Extensions/SnaplinePlacementBehavior.cs
@@ -302,27 +302,33 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		private IEnumerable<DesignItem> AllDesignItems(DesignItem designItem = null)
 		{
 			if (designItem == null && this.ExtendedItem.Services.DesignPanel is DesignPanel)
-			{
 				designItem = this.ExtendedItem.Services.DesignPanel.Context.RootItem;
-				if (designItem != null) {
-					yield return designItem;
-					if (designItem.ContentProperty.Value != null) {
-						yield return designItem.ContentProperty.Value;
-						designItem = designItem.ContentProperty.Value;
+
+			if (designItem?.ContentProperty != null)
+			{
+				if (designItem.ContentProperty.IsCollection)
+				{
+					foreach (var collectionElement in designItem.ContentProperty.CollectionElements)
+					{
+						if (collectionElement != null)
+							yield return collectionElement;
+
+						foreach (var el in AllDesignItems(collectionElement))
+						{
+							if (el != null)
+								yield return el;
+						}
 					}
 				}
-			}
-			
-			if (designItem != null && designItem.ContentProperty != null && designItem.ContentProperty.IsCollection)
-				foreach (var collectionElement in designItem.ContentProperty.CollectionElements)
-			{
-				if (collectionElement != null)
-					yield return collectionElement;
-				
-				foreach (var el in AllDesignItems(collectionElement))
+				else if (designItem.ContentProperty.Value != null)
 				{
-					if (el != null)
-						yield return el;
+					yield return designItem.ContentProperty.Value;
+
+					foreach (var el in AllDesignItems(designItem.ContentProperty.Value))
+					{
+						if (el != null)
+							yield return el;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Snaplines were only added for controls when all parent controls (except for root) had a Content property that was a collection.

Consider the structure Window -> Canvas -> UserControl -> Canvas -> Childs.

The childs of the last canvas did not get snaplines because the canvas is child of a ContentControl which accepts only one child.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the WPF Designer open source product (the "Contribution"). My Contribution is licensed under the MIT License.