### PR TITLE
Fixed bug where extensions are reapplied multiple times

### DIFF
--- a/WpfDesign/Project/DesignItem.cs
+++ b/WpfDesign/Project/DesignItem.cs
@@ -228,10 +228,11 @@ namespace ICSharpCode.WpfDesign
 		public void ReapplyAllExtensions()
 		{
 			var manager = this.Services.GetService<Extensions.ExtensionManager>();
+		    List<ExtensionServer> servers =_extensions.GroupBy(entry => entry.Server).Select(grp => grp.First().Server).ToList();
 
-			foreach (var e in this._extensions.ToList()) {
-				ApplyUnapplyExtensionServer(manager, false, e.Server);
-				ApplyUnapplyExtensionServer(manager, true, e.Server);
+			foreach (var server in servers) {
+				ApplyUnapplyExtensionServer(manager, false, server);
+				ApplyUnapplyExtensionServer(manager, true, server);
 			}
 		}
 


### PR DESCRIPTION
Fixed a bug in DesignItem.ReapplyAllExtensions() where extensions were reapplied multiple times. The extensions were being reapplied the same number of times as the total number of extensions applied for the ExtensionServer.

Result was that if ReapplyAllExtensions() was called on a DesignItem with 8 extensions applied from the same ExtensionServer, then all 8 extensions were reapplied  8 times.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the WPF Designer open source product (the "Contribution"). My Contribution is licensed under the MIT License.