### PR TITLE
Removed hardcoded culture

### DIFF
--- a/WpfDesign.Designer/Project/DesignSurface.cs
+++ b/WpfDesign.Designer/Project/DesignSurface.cs
@@ -29,8 +29,6 @@ using ICSharpCode.WpfDesign.Designer.Xaml;
 using ICSharpCode.WpfDesign.Designer.Services;
 using ICSharpCode.WpfDesign.Designer.Controls;
 using System.Diagnostics;
-using System.Threading;
-using System.Globalization;
 
 namespace ICSharpCode.WpfDesign.Designer
 {
@@ -50,9 +48,6 @@ namespace ICSharpCode.WpfDesign.Designer
 		
 		public DesignSurface()
 		{
-			//TODO: this is for converters (see PropertyGrid)
-			Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-
 			//Propertygrid should show no inherited Datacontext!
 			this.DataContext = null;
 

--- a/WpfDesign.Designer/Project/PropertyGrid/Editors/NumberEditor.xaml.cs
+++ b/WpfDesign.Designer/Project/PropertyGrid/Editors/NumberEditor.xaml.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -165,24 +166,57 @@ namespace ICSharpCode.WpfDesign.Designer.PropertyGrid.Editors
 			if(textBox==null)
 				return;
 			double val;
-			if(double.TryParse(textBox.Text, out val)){
-				if(PropertyNode.FirstProperty.TypeConverter.IsValid(textBox.Text)){
-					if(val >= Minimum && val <= Maximum || double.IsNaN(val)){
-						textBox.Foreground=Brushes.Black;
-						textBox.ToolTip=textBox.Text;
-					}else{
-						textBox.Foreground = Brushes.DarkBlue;
-						textBox.ToolTip = "Value should be in between "+Minimum+" and "+Maximum;
+
+			if(double.TryParse(textBox.Text, out val))
+			{
+				if (IsValidTypeConverter(PropertyNode.FirstProperty.TypeConverter, textBox.Text))
+				{
+					if (val >= Minimum && val <= Maximum || double.IsNaN(val))
+					{
+						textBox.Foreground = Brushes.Black;
+						textBox.ToolTip = textBox.Text;
 					}
-				}else{
+					else
+					{
+						textBox.Foreground = Brushes.DarkBlue;
+						textBox.ToolTip = "Value should be in between " + Minimum + " and " + Maximum;
+					}
+				}
+				else
+				{
 					textBox.Foreground = Brushes.DarkRed;
 					textBox.ToolTip = "Cannot convert to Type : " + PropertyNode.FirstProperty.ReturnType.Name;
 				}
-			}else{
-				textBox.Foreground = Brushes.DarkRed;
-				textBox.ToolTip = string.IsNullOrWhiteSpace(textBox.Text)? null:"Value does not belong to any numeric type";
 			}
-			
+			else
+			{
+				textBox.Foreground = Brushes.DarkRed;
+				textBox.ToolTip = string.IsNullOrWhiteSpace(textBox.Text) ? null : "Value does not belong to any numeric type";
+			}
+		}
+
+		// Method used instead of System.ComponentModel.TypeConverter.IsValid()
+		// This ensures that TypeConverter is validated based on the current culture
+		// See: https://stackoverflow.com/questions/16837774/typeconverter-isvalid-uses-current-thread-culture-but-typeconverter-convertfro
+		private static bool IsValidTypeConverter(TypeConverter typeConverter, object value)
+		{
+			bool isValid = true;
+			try
+			{
+				if (value == null || typeConverter.CanConvertFrom(value.GetType()))
+				{
+					typeConverter.ConvertFrom(value);
+				}
+				else
+				{
+					isValid = false;
+				}
+			}
+			catch
+			{
+				isValid = false;
+			}
+			return isValid;
 		}
 
 		ChangeGroup group;


### PR DESCRIPTION
In the DesignSurface class the CurrentCulture is explicitely set to "InvariantCulture".

The result of this is that values presented in the PropertyGrid is always formatted using the InvariantCulture. Regional settings are ignored.

The hardcoded culture has in my case also caused a problem because I need to localize the application in which I integrate WpfDesigner.

I have investigated why the culture is explicitely set. I have only found a problem in NumberEditor where the entered value was always validated using InvariantCulture. I have fixed this so it now validates using CurrentCulture.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the WPF Designer open source product (the "Contribution"). My Contribution is licensed under the MIT License.