### PR TITLE
Fixed cross-thread-exception

### DIFF
--- a/WpfDesign.Designer/Project/Converters.cs
+++ b/WpfDesign.Designer/Project/Converters.cs
@@ -260,7 +260,13 @@ namespace ICSharpCode.WpfDesign.Designer.Converters
 		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "converter is immutable")]
 		public static readonly BlackWhenTrue Instance = new BlackWhenTrue();
 
-		private Brush black = new SolidColorBrush(Colors.Black);
+		private Brush black;
+
+		public BlackWhenTrue()
+		{
+			black = new SolidColorBrush(Colors.Black);
+			black.Freeze();
+		}
 
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{


### PR DESCRIPTION
Fixed cross-thread-exception, static converter instance should return a frozen brush.

I certify that I own, and have sufficient rights to contribute, all source code and related material intended to be compiled or integrated with the source code for the WPF Designer open source product (the "Contribution"). My Contribution is licensed under the MIT License.