### PR TITLE
don't access Application.Current.MainWindow, causes cross-thread-exce…

### DIFF
--- a/WpfDesign.Designer/Project/Extensions/QuickOperationMenuExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/QuickOperationMenuExtension.cs
@@ -121,7 +121,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				if (parent != null) {
 					
 					if((string)clickedOn.Header=="Edit Items") {
-						var editor = new CollectionEditor();
+						var editor = new CollectionEditor(Window.GetWindow(this.ExtendedItem.View));
 						var itemsControl=this.ExtendedItem.View as ItemsControl;
 						if (itemsControl != null)
 							editor.LoadItemsCollection(this.ExtendedItem);
@@ -129,7 +129,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 					}
 					
 					if((string)clickedOn.Header=="Edit Rows") {
-						var editor = new FlatCollectionEditor();
+						var editor = new FlatCollectionEditor(Window.GetWindow(this.ExtendedItem.View));
 						var gd=this.ExtendedItem.View as Grid;
 						if (gd != null)
 							editor.LoadItemsCollection(this.ExtendedItem.Properties["RowDefinitions"]);
@@ -137,7 +137,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 					}
 					
 					if((string)clickedOn.Header=="Edit Columns") {
-						var editor = new FlatCollectionEditor();
+						var editor = new FlatCollectionEditor(Window.GetWindow(this.ExtendedItem.View));
 						var gd=this.ExtendedItem.View as Grid;
 						if (gd != null)
 							editor.LoadItemsCollection(this.ExtendedItem.Properties["ColumnDefinitions"]);

--- a/WpfDesign.Designer/Project/PropertyGrid/Editors/CollectionEditor.xaml.cs
+++ b/WpfDesign.Designer/Project/PropertyGrid/Editors/CollectionEditor.xaml.cs
@@ -43,11 +43,16 @@ namespace ICSharpCode.WpfDesign.Designer.PropertyGrid.Editors
 		private DesignItem _item;
 		private Type _type;
 		private IComponentService _componentService;
+
 		public CollectionEditor()
 		{
 			SpecialInitializeComponent();
-			
-			this.Owner = Application.Current.MainWindow;
+		}
+
+		public CollectionEditor(Window owner)
+			: this()
+		{
+			this.Owner = owner;
 		}
 		
 		/// <summary>

--- a/WpfDesign.Designer/Project/PropertyGrid/Editors/FlatCollectionEditor.xaml.cs
+++ b/WpfDesign.Designer/Project/PropertyGrid/Editors/FlatCollectionEditor.xaml.cs
@@ -42,12 +42,16 @@ namespace ICSharpCode.WpfDesign.Designer.PropertyGrid.Editors
 		private DesignItemProperty _itemProperty;
 		private IComponentService _componentService;
 		private Type _type;
-		
+
 		public FlatCollectionEditor()
 		{
 			SpecialInitializeComponent();
+		}
 
-			this.Owner = Application.Current.MainWindow;
+		public FlatCollectionEditor(Window owner)
+			: this()
+		{
+			this.Owner = owner;
 		}
 		
 		/// <summary>

--- a/WpfDesign.Designer/Project/PropertyGrid/Editors/OpenCollectionEditor.xaml.cs
+++ b/WpfDesign.Designer/Project/PropertyGrid/Editors/OpenCollectionEditor.xaml.cs
@@ -51,7 +51,7 @@ namespace ICSharpCode.WpfDesign.Designer.PropertyGrid.Editors
 		{
 			var node = this.DataContext as PropertyNode;
 			
-			var editor = new FlatCollectionEditor();
+			var editor = new FlatCollectionEditor(Window.GetWindow(this));
 			editor.LoadItemsCollection(node.FirstProperty);
 			editor.ShowDialog();
 		}


### PR DESCRIPTION
don't access Application.Current.MainWindow, causes cross-thread-exception in application with multi-threaded UI

nb. not sure if setting the Owner is required at all, but this way is minimizes impact of the change