### PR TITLE
use type converter for converting instance values when available instead of direct casting

### DIFF
--- a/WpfDesign.Designer/Project/Controls/GridAdorner.cs
+++ b/WpfDesign.Designer/Project/Controls/GridAdorner.cs
@@ -140,7 +140,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.HeightOffset = 55;
 					rpUnitSelector.YOffset = current.Offset + current.ActualHeight / 2 - 25;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = component.Properties[RowDefinition.HeightProperty].GetValueOnInstance<GridLength>().GridUnitType;
+					unitSelector.Unit = component.Properties[RowDefinition.HeightProperty].GetConvertedValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -164,7 +164,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.WidthOffset = 75;
 					rpUnitSelector.XOffset = current.Offset + current.ActualWidth / 2 - 35;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = component.Properties[ColumnDefinition.WidthProperty].GetValueOnInstance<GridLength>().GridUnitType;
+					unitSelector.Unit = component.Properties[ColumnDefinition.WidthProperty].GetConvertedValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -205,7 +205,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.HeightOffset = 55;
 					rpUnitSelector.YOffset = current.Offset + current.ActualHeight / 2 - 25;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = component.Properties[RowDefinition.HeightProperty].GetValueOnInstance<GridLength>().GridUnitType;
+					unitSelector.Unit = component.Properties[RowDefinition.HeightProperty].GetConvertedValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -236,7 +236,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.WidthOffset = 75;
 					rpUnitSelector.XOffset = current.Offset + current.ActualWidth / 2 - 35;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = component.Properties[ColumnDefinition.WidthProperty].GetValueOnInstance<GridLength>().GridUnitType;
+					unitSelector.Unit = component.Properties[ColumnDefinition.WidthProperty].GetConvertedValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -368,11 +368,11 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				// increment ColSpan of all controls in the split column, increment Column of all controls in later columns:
 				foreach (DesignItem child in gridItem.Properties["Children"].CollectionElements) {
 					Point topLeft = child.View.TranslatePoint(new Point(0, 0), grid);
-					var margin = child.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
-					var start = child.Properties.GetAttachedProperty(idxProperty).GetValueOnInstance<int>();
-					var span = child.Properties.GetAttachedProperty(spanProperty).GetValueOnInstance<int>();
+					var margin = child.Properties[FrameworkElement.MarginProperty].GetConvertedValueOnInstance<Thickness>();
+					var start = child.Properties.GetAttachedProperty(idxProperty).GetConvertedValueOnInstance<int>();
+					var span = child.Properties.GetAttachedProperty(spanProperty).GetConvertedValueOnInstance<int>();
 					if (start <= splitIndex && splitIndex < start + span) {
-						var width = child.Properties[FrameworkElement.ActualWidthProperty].GetValueOnInstance<double>();
+						var width = child.Properties[FrameworkElement.ActualWidthProperty].GetConvertedValueOnInstance<double>();
 						if (insertionPostion >= topLeft.X + width) {
 							continue;
 						}
@@ -395,12 +395,12 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				foreach (DesignItem child in gridItem.Properties["Children"].CollectionElements)
 				{
 					Point topLeft = child.View.TranslatePoint(new Point(0, 0), grid);
-					var margin = child.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
-					var start = child.Properties.GetAttachedProperty(idxProperty).GetValueOnInstance<int>();
-					var span = child.Properties.GetAttachedProperty(spanProperty).GetValueOnInstance<int>();
+					var margin = child.Properties[FrameworkElement.MarginProperty].GetConvertedValueOnInstance<Thickness>();
+					var start = child.Properties.GetAttachedProperty(idxProperty).GetConvertedValueOnInstance<int>();
+					var span = child.Properties.GetAttachedProperty(spanProperty).GetConvertedValueOnInstance<int>();
 					if (start <= splitIndex && splitIndex < start + span)
 					{
-						var height = child.Properties[FrameworkElement.ActualHeightProperty].GetValueOnInstance<double>();
+						var height = child.Properties[FrameworkElement.ActualHeightProperty].GetConvertedValueOnInstance<double>();
 						if (insertionPostion >= topLeft.Y + height)
 							continue;
 						if (insertionPostion > topLeft.Y)
@@ -463,7 +463,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 		void SetGridLengthUnit(GridUnitType unit, DesignItem item, DependencyProperty property)
 		{
 			DesignItemProperty itemProperty = item.Properties[property];
-			GridLength oldValue = itemProperty.GetValueOnInstance<GridLength>();
+			GridLength oldValue = itemProperty.GetConvertedValueOnInstance<GridLength>();
 			GridLength value = GetNewGridLength(unit, oldValue);
 			
 			if (value != oldValue) {

--- a/WpfDesign.Designer/Project/Controls/GridAdorner.cs
+++ b/WpfDesign.Designer/Project/Controls/GridAdorner.cs
@@ -140,7 +140,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.HeightOffset = 55;
 					rpUnitSelector.YOffset = current.Offset + current.ActualHeight / 2 - 25;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = ((GridLength)component.Properties[RowDefinition.HeightProperty].ValueOnInstance).GridUnitType;
+					unitSelector.Unit = component.Properties[RowDefinition.HeightProperty].GetValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -164,7 +164,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.WidthOffset = 75;
 					rpUnitSelector.XOffset = current.Offset + current.ActualWidth / 2 - 35;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = ((GridLength)component.Properties[ColumnDefinition.WidthProperty].ValueOnInstance).GridUnitType;
+					unitSelector.Unit = component.Properties[ColumnDefinition.WidthProperty].GetValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -205,7 +205,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.HeightOffset = 55;
 					rpUnitSelector.YOffset = current.Offset + current.ActualHeight / 2 - 25;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = ((GridLength)component.Properties[RowDefinition.HeightProperty].ValueOnInstance).GridUnitType;
+					unitSelector.Unit = component.Properties[RowDefinition.HeightProperty].GetValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -236,7 +236,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 					rpUnitSelector.WidthOffset = 75;
 					rpUnitSelector.XOffset = current.Offset + current.ActualWidth / 2 - 35;
 					unitSelector.SelectedItem = component;
-					unitSelector.Unit = ((GridLength)component.Properties[ColumnDefinition.WidthProperty].ValueOnInstance).GridUnitType;
+					unitSelector.Unit = component.Properties[ColumnDefinition.WidthProperty].GetValueOnInstance<GridLength>().GridUnitType;
 					displayUnitSelector = true;
 				}
 				else
@@ -369,10 +369,10 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				foreach (DesignItem child in gridItem.Properties["Children"].CollectionElements) {
 					Point topLeft = child.View.TranslatePoint(new Point(0, 0), grid);
 					var margin = child.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
-					var start = (int) child.Properties.GetAttachedProperty(idxProperty).ValueOnInstance;
-					var span = (int) child.Properties.GetAttachedProperty(spanProperty).ValueOnInstance;
+					var start = child.Properties.GetAttachedProperty(idxProperty).GetValueOnInstance<int>();
+					var span = child.Properties.GetAttachedProperty(spanProperty).GetValueOnInstance<int>();
 					if (start <= splitIndex && splitIndex < start + span) {
-						var width = (double) child.Properties[FrameworkElement.ActualWidthProperty].ValueOnInstance;
+						var width = child.Properties[FrameworkElement.ActualWidthProperty].GetValueOnInstance<double>();
 						if (insertionPostion >= topLeft.X + width) {
 							continue;
 						}
@@ -396,11 +396,11 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				{
 					Point topLeft = child.View.TranslatePoint(new Point(0, 0), grid);
 					var margin = child.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
-					var start = (int)child.Properties.GetAttachedProperty(idxProperty).ValueOnInstance;
-					var span = (int)child.Properties.GetAttachedProperty(spanProperty).ValueOnInstance;
+					var start = child.Properties.GetAttachedProperty(idxProperty).GetValueOnInstance<int>();
+					var span = child.Properties.GetAttachedProperty(spanProperty).GetValueOnInstance<int>();
 					if (start <= splitIndex && splitIndex < start + span)
 					{
-						var height = (double)child.Properties[FrameworkElement.ActualHeightProperty].ValueOnInstance;
+						var height = child.Properties[FrameworkElement.ActualHeightProperty].GetValueOnInstance<double>();
 						if (insertionPostion >= topLeft.Y + height)
 							continue;
 						if (insertionPostion > topLeft.Y)
@@ -463,7 +463,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 		void SetGridLengthUnit(GridUnitType unit, DesignItem item, DependencyProperty property)
 		{
 			DesignItemProperty itemProperty = item.Properties[property];
-			GridLength oldValue = (GridLength)itemProperty.ValueOnInstance;
+			GridLength oldValue = itemProperty.GetValueOnInstance<GridLength>();
 			GridLength value = GetNewGridLength(unit, oldValue);
 			
 			if (value != oldValue) {

--- a/WpfDesign.Designer/Project/Controls/GridAdorner.cs
+++ b/WpfDesign.Designer/Project/Controls/GridAdorner.cs
@@ -368,7 +368,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				// increment ColSpan of all controls in the split column, increment Column of all controls in later columns:
 				foreach (DesignItem child in gridItem.Properties["Children"].CollectionElements) {
 					Point topLeft = child.View.TranslatePoint(new Point(0, 0), grid);
-					var margin = (Thickness) child.Properties[FrameworkElement.MarginProperty].ValueOnInstance;
+					var margin = child.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
 					var start = (int) child.Properties.GetAttachedProperty(idxProperty).ValueOnInstance;
 					var span = (int) child.Properties.GetAttachedProperty(spanProperty).ValueOnInstance;
 					if (start <= splitIndex && splitIndex < start + span) {
@@ -395,7 +395,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				foreach (DesignItem child in gridItem.Properties["Children"].CollectionElements)
 				{
 					Point topLeft = child.View.TranslatePoint(new Point(0, 0), grid);
-					var margin = (Thickness)child.Properties[FrameworkElement.MarginProperty].ValueOnInstance;
+					var margin = child.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
 					var start = (int)child.Properties.GetAttachedProperty(idxProperty).ValueOnInstance;
 					var span = (int)child.Properties.GetAttachedProperty(spanProperty).ValueOnInstance;
 					if (start <= splitIndex && splitIndex < start + span)

--- a/WpfDesign.Designer/Project/Controls/InPlaceEditor.cs
+++ b/WpfDesign.Designer/Project/Controls/InPlaceEditor.cs
@@ -104,15 +104,15 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				{
 					case Key.Enter:
 						// Commit the changes to DOM.
-						if (designItem.Properties[Control.FontFamilyProperty].GetValueOnInstance<FontFamily>() != editor.FontFamily)
+						if (designItem.Properties[Control.FontFamilyProperty].GetConvertedValueOnInstance<FontFamily>() != editor.FontFamily)
 							designItem.Properties[Control.FontFamilyProperty].SetValue(editor.FontFamily);
-						if (designItem.Properties[Control.FontSizeProperty].GetValueOnInstance<double>() != editor.FontSize)
+						if (designItem.Properties[Control.FontSizeProperty].GetConvertedValueOnInstance<double>() != editor.FontSize)
 							designItem.Properties[Control.FontSizeProperty].SetValue(editor.FontSize);
-						if (designItem.Properties[Control.FontStretchProperty].GetValueOnInstance<FontStretch>() != editor.FontStretch)
+						if (designItem.Properties[Control.FontStretchProperty].GetConvertedValueOnInstance<FontStretch>() != editor.FontStretch)
 							designItem.Properties[Control.FontStretchProperty].SetValue(editor.FontStretch);
-						if (designItem.Properties[Control.FontStyleProperty].GetValueOnInstance<FontStyle>() != editor.FontStyle)
+						if (designItem.Properties[Control.FontStyleProperty].GetConvertedValueOnInstance<FontStyle>() != editor.FontStyle)
 							designItem.Properties[Control.FontStyleProperty].SetValue(editor.FontStyle);
-						if (designItem.Properties[Control.FontWeightProperty].GetValueOnInstance<FontWeight>() != editor.FontWeight)
+						if (designItem.Properties[Control.FontWeightProperty].GetConvertedValueOnInstance<FontWeight>() != editor.FontWeight)
 							designItem.Properties[Control.FontWeightProperty].SetValue(editor.FontWeight);
 
 						if (changeGroup != null && _isChangeGroupOpen)

--- a/WpfDesign.Designer/Project/Controls/InPlaceEditor.cs
+++ b/WpfDesign.Designer/Project/Controls/InPlaceEditor.cs
@@ -21,6 +21,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Documents;
 using System.Windows.Input;
+using System.Windows.Media;
 using ICSharpCode.WpfDesign.Designer.PropertyGrid.Editors.FormatedTextEditor;
 using RichTextBox = System.Windows.Controls.RichTextBox;
 
@@ -103,15 +104,15 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 				{
 					case Key.Enter:
 						// Commit the changes to DOM.
-						if (designItem.Properties[Control.FontFamilyProperty].ValueOnInstance != editor.FontFamily)
+						if (designItem.Properties[Control.FontFamilyProperty].GetValueOnInstance<FontFamily>() != editor.FontFamily)
 							designItem.Properties[Control.FontFamilyProperty].SetValue(editor.FontFamily);
-						if ((double)designItem.Properties[Control.FontSizeProperty].ValueOnInstance != editor.FontSize)
+						if (designItem.Properties[Control.FontSizeProperty].GetValueOnInstance<double>() != editor.FontSize)
 							designItem.Properties[Control.FontSizeProperty].SetValue(editor.FontSize);
-						if ((FontStretch)designItem.Properties[Control.FontStretchProperty].ValueOnInstance != editor.FontStretch)
+						if (designItem.Properties[Control.FontStretchProperty].GetValueOnInstance<FontStretch>() != editor.FontStretch)
 							designItem.Properties[Control.FontStretchProperty].SetValue(editor.FontStretch);
-						if ((FontStyle)designItem.Properties[Control.FontStyleProperty].ValueOnInstance != editor.FontStyle)
+						if (designItem.Properties[Control.FontStyleProperty].GetValueOnInstance<FontStyle>() != editor.FontStyle)
 							designItem.Properties[Control.FontStyleProperty].SetValue(editor.FontStyle);
-						if ((FontWeight)designItem.Properties[Control.FontWeightProperty].ValueOnInstance != editor.FontWeight)
+						if (designItem.Properties[Control.FontWeightProperty].GetValueOnInstance<FontWeight>() != editor.FontWeight)
 							designItem.Properties[Control.FontWeightProperty].SetValue(editor.FontWeight);
 
 						if (changeGroup != null && _isChangeGroupOpen)

--- a/WpfDesign.Designer/Project/Controls/MarginHandle.cs
+++ b/WpfDesign.Designer/Project/Controls/MarginHandle.cs
@@ -216,7 +216,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 		void OnPropertyChanged(object sender,PropertyChangedEventArgs e)
 		{
 			if(e.PropertyName=="HorizontalAlignment" && (orientation==HandleOrientation.Left || orientation==HandleOrientation.Right)) {
-				var ha = adornedControlItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
+				var ha = adornedControlItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetConvertedValueOnInstance<HorizontalAlignment>();
 				if(ha==HorizontalAlignment.Stretch) {
 					DisplayOnlyStub = false;
 				}else if(ha==HorizontalAlignment.Center) {
@@ -226,7 +226,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 			}
 
 			if(e.PropertyName=="VerticalAlignment" && (orientation==HandleOrientation.Top || orientation==HandleOrientation.Bottom)) {
-				var va = adornedControlItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
+				var va = adornedControlItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetConvertedValueOnInstance<VerticalAlignment>();
 
 				if(va==VerticalAlignment.Stretch) {
 					DisplayOnlyStub = false;

--- a/WpfDesign.Designer/Project/Controls/MarginHandle.cs
+++ b/WpfDesign.Designer/Project/Controls/MarginHandle.cs
@@ -216,7 +216,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 		void OnPropertyChanged(object sender,PropertyChangedEventArgs e)
 		{
 			if(e.PropertyName=="HorizontalAlignment" && (orientation==HandleOrientation.Left || orientation==HandleOrientation.Right)) {
-				var ha = (HorizontalAlignment) adornedControlItem.Properties[FrameworkElement.HorizontalAlignmentProperty].ValueOnInstance;
+				var ha = adornedControlItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
 				if(ha==HorizontalAlignment.Stretch) {
 					DisplayOnlyStub = false;
 				}else if(ha==HorizontalAlignment.Center) {
@@ -226,7 +226,7 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 			}
 
 			if(e.PropertyName=="VerticalAlignment" && (orientation==HandleOrientation.Top || orientation==HandleOrientation.Bottom)) {
-				var va = (VerticalAlignment)adornedControlItem.Properties[FrameworkElement.VerticalAlignmentProperty].ValueOnInstance;
+				var va = adornedControlItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
 
 				if(va==VerticalAlignment.Stretch) {
 					DisplayOnlyStub = false;

--- a/WpfDesign.Designer/Project/Extensions/CanvasPlacementSupport.cs
+++ b/WpfDesign.Designer/Project/Extensions/CanvasPlacementSupport.cs
@@ -147,15 +147,15 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				info.Item.Properties[FrameworkElement.MarginProperty].Reset();
 				
 				if (operation.Type == PlacementType.PasteItem) {
-					if (!double.IsNaN(info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).GetValueOnInstance<double>())) {
+					if (!double.IsNaN(info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).GetConvertedValueOnInstance<double>())) {
 						info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty)
-							.SetValue((info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).GetValueOnInstance<double>()) +
+							.SetValue((info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).GetConvertedValueOnInstance<double>()) +
 							          PlacementOperation.PasteOffset);
 					}
 
-					if (!double.IsNaN(info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).GetValueOnInstance<double>())) {
+					if (!double.IsNaN(info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).GetConvertedValueOnInstance<double>())) {
 						info.Item.Properties.GetAttachedProperty(Canvas.TopProperty)
-							.SetValue((info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).GetValueOnInstance<double>()) +
+							.SetValue((info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).GetConvertedValueOnInstance<double>()) +
 							          PlacementOperation.PasteOffset);
 					}
 				}

--- a/WpfDesign.Designer/Project/Extensions/CanvasPlacementSupport.cs
+++ b/WpfDesign.Designer/Project/Extensions/CanvasPlacementSupport.cs
@@ -147,15 +147,15 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				info.Item.Properties[FrameworkElement.MarginProperty].Reset();
 				
 				if (operation.Type == PlacementType.PasteItem) {
-					if (!double.IsNaN((double)info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).ValueOnInstance)) {
+					if (!double.IsNaN(info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).GetValueOnInstance<double>())) {
 						info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty)
-							.SetValue(((double) info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).ValueOnInstance) +
+							.SetValue((info.Item.Properties.GetAttachedProperty(Canvas.LeftProperty).GetValueOnInstance<double>()) +
 							          PlacementOperation.PasteOffset);
 					}
 
-					if (!double.IsNaN((double)info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).ValueOnInstance)) {
+					if (!double.IsNaN(info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).GetValueOnInstance<double>())) {
 						info.Item.Properties.GetAttachedProperty(Canvas.TopProperty)
-							.SetValue(((double) info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).ValueOnInstance) +
+							.SetValue((info.Item.Properties.GetAttachedProperty(Canvas.TopProperty).GetValueOnInstance<double>()) +
 							          PlacementOperation.PasteOffset);
 					}
 				}

--- a/WpfDesign.Designer/Project/Extensions/DefaultPlacementBehavior.cs
+++ b/WpfDesign.Designer/Project/Extensions/DefaultPlacementBehavior.cs
@@ -159,7 +159,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			if (!ExtendedItem.ContentProperty.IsSet)
 				return true;
 
-			object value = ExtendedItem.ContentProperty.ValueOnInstance;
+			object value = ExtendedItem.ContentProperty.GetValueOnInstance<object>();
 			// don't overwrite non-primitive values like bindings
 			return ExtendedItem.ContentProperty.Value == null && (value is string && string.IsNullOrEmpty(value as string));
 		}

--- a/WpfDesign.Designer/Project/Extensions/DefaultPlacementBehavior.cs
+++ b/WpfDesign.Designer/Project/Extensions/DefaultPlacementBehavior.cs
@@ -159,7 +159,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			if (!ExtendedItem.ContentProperty.IsSet)
 				return true;
 
-			object value = ExtendedItem.ContentProperty.GetValueOnInstance<object>();
+			object value = ExtendedItem.ContentProperty.GetConvertedValueOnInstance<object>();
 			// don't overwrite non-primitive values like bindings
 			return ExtendedItem.ContentProperty.Value == null && (value is string && string.IsNullOrEmpty(value as string));
 		}

--- a/WpfDesign.Designer/Project/Extensions/GridPlacementSupport.cs
+++ b/WpfDesign.Designer/Project/Extensions/GridPlacementSupport.cs
@@ -190,8 +190,8 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			if (operation.Type == PlacementType.PasteItem) {
 				foreach (PlacementInformation info in operation.PlacedItems) {				
 					var margin = info.Item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
-					var horizontalAlignment = (HorizontalAlignment)info.Item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance;
-					var verticalAlignment = (VerticalAlignment)info.Item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance;
+					var horizontalAlignment = info.Item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>();
+					var verticalAlignment = info.Item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>();
 					
 					if (horizontalAlignment == HorizontalAlignment.Left)
 						margin.Left += PlacementOperation.PasteOffset;
@@ -242,8 +242,8 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				}
 			}
 			
-			HorizontalAlignment ha = (HorizontalAlignment)info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].ValueOnInstance;
-			VerticalAlignment va = (VerticalAlignment)info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].ValueOnInstance;
+			HorizontalAlignment ha = info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
+			VerticalAlignment va = info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
 			if(enteredIntoNewContainer){
 				ha = SuggestHorizontalAlignment(info.Bounds, availableSpaceRect);
 				va = SuggestVerticalAlignment(info.Bounds, availableSpaceRect);
@@ -289,8 +289,8 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 					info.Item.Properties.GetAttachedProperty(Grid.RowSpanProperty).Reset();
 					info.Item.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).Reset();
 
-					HorizontalAlignment ha = (HorizontalAlignment)info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].ValueOnInstance;
-					VerticalAlignment va = (VerticalAlignment)info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].ValueOnInstance;
+					HorizontalAlignment ha = info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
+					VerticalAlignment va = info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
 
 					if (ha == HorizontalAlignment.Stretch)
 						info.Item.Properties[FrameworkElement.WidthProperty].SetValue(info.Bounds.Width);

--- a/WpfDesign.Designer/Project/Extensions/GridPlacementSupport.cs
+++ b/WpfDesign.Designer/Project/Extensions/GridPlacementSupport.cs
@@ -189,9 +189,9 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			
 			if (operation.Type == PlacementType.PasteItem) {
 				foreach (PlacementInformation info in operation.PlacedItems) {				
-					var margin = info.Item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
-					var horizontalAlignment = info.Item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>();
-					var verticalAlignment = info.Item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>();
+					var margin = info.Item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
+					var horizontalAlignment = info.Item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetConvertedValueOnInstance<HorizontalAlignment>();
+					var verticalAlignment = info.Item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetConvertedValueOnInstance<VerticalAlignment>();
 					
 					if (horizontalAlignment == HorizontalAlignment.Left)
 						margin.Left += PlacementOperation.PasteOffset;
@@ -242,8 +242,8 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				}
 			}
 			
-			HorizontalAlignment ha = info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
-			VerticalAlignment va = info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
+			HorizontalAlignment ha = info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].GetConvertedValueOnInstance<HorizontalAlignment>();
+			VerticalAlignment va = info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].GetConvertedValueOnInstance<VerticalAlignment>();
 			if(enteredIntoNewContainer){
 				ha = SuggestHorizontalAlignment(info.Bounds, availableSpaceRect);
 				va = SuggestVerticalAlignment(info.Bounds, availableSpaceRect);
@@ -289,8 +289,8 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 					info.Item.Properties.GetAttachedProperty(Grid.RowSpanProperty).Reset();
 					info.Item.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).Reset();
 
-					HorizontalAlignment ha = info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
-					VerticalAlignment va = info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
+					HorizontalAlignment ha = info.Item.Properties[FrameworkElement.HorizontalAlignmentProperty].GetConvertedValueOnInstance<HorizontalAlignment>();
+					VerticalAlignment va = info.Item.Properties[FrameworkElement.VerticalAlignmentProperty].GetConvertedValueOnInstance<VerticalAlignment>();
 
 					if (ha == HorizontalAlignment.Stretch)
 						info.Item.Properties[FrameworkElement.WidthProperty].SetValue(info.Bounds.Width);

--- a/WpfDesign.Designer/Project/Extensions/GridPlacementSupport.cs
+++ b/WpfDesign.Designer/Project/Extensions/GridPlacementSupport.cs
@@ -189,7 +189,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			
 			if (operation.Type == PlacementType.PasteItem) {
 				foreach (PlacementInformation info in operation.PlacedItems) {				
-					var margin = (Thickness)info.Item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+					var margin = info.Item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 					var horizontalAlignment = (HorizontalAlignment)info.Item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance;
 					var verticalAlignment = (VerticalAlignment)info.Item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance;
 					

--- a/WpfDesign.Designer/Project/Extensions/MarginHandleExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/MarginHandleExtension.cs
@@ -72,13 +72,13 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		private void OnMouseDown(object sender, MouseButtonEventArgs e)
 		{
 			e.Handled = true;
-			var row = this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowProperty).GetValueOnInstance<int>();
-			var rowSpan = this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetValueOnInstance<int>();
+			var row = this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowProperty).GetConvertedValueOnInstance<int>();
+			var rowSpan = this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetConvertedValueOnInstance<int>();
 
-			var column = this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnProperty).GetValueOnInstance<int>();
-			var columnSpan = this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetValueOnInstance<int>();
+			var column = this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnProperty).GetConvertedValueOnInstance<int>();
+			var columnSpan = this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetConvertedValueOnInstance<int>();
 
-			var margin = this.ExtendedItem.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
+			var margin = this.ExtendedItem.Properties[FrameworkElement.MarginProperty].GetConvertedValueOnInstance<Thickness>();
 
 			var point = this.ExtendedItem.View.TranslatePoint(new Point(), _grid);
 			var position = new Rect(point, PlacementOperation.GetRealElementSize(this.ExtendedItem.View));

--- a/WpfDesign.Designer/Project/Extensions/MarginHandleExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/MarginHandleExtension.cs
@@ -72,11 +72,11 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		private void OnMouseDown(object sender, MouseButtonEventArgs e)
 		{
 			e.Handled = true;
-			var row = (int) this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowProperty).ValueOnInstance;
-			var rowSpan = (int) this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowSpanProperty).ValueOnInstance;
+			var row = this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowProperty).GetValueOnInstance<int>();
+			var rowSpan = this.ExtendedItem.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetValueOnInstance<int>();
 
-			var column = (int) this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnProperty).ValueOnInstance;
-			var columnSpan = (int) this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).ValueOnInstance;
+			var column = this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnProperty).GetValueOnInstance<int>();
+			var columnSpan = this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetValueOnInstance<int>();
 
 			var margin = this.ExtendedItem.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
 

--- a/WpfDesign.Designer/Project/Extensions/MarginHandleExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/MarginHandleExtension.cs
@@ -78,7 +78,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			var column = (int) this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnProperty).ValueOnInstance;
 			var columnSpan = (int) this.ExtendedItem.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).ValueOnInstance;
 
-			var margin = (Thickness) this.ExtendedItem.Properties[FrameworkElement.MarginProperty].ValueOnInstance;
+			var margin = this.ExtendedItem.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>();
 
 			var point = this.ExtendedItem.View.TranslatePoint(new Point(), _grid);
 			var position = new Rect(point, PlacementOperation.GetRealElementSize(this.ExtendedItem.View));

--- a/WpfDesign.Designer/Project/Extensions/QuickOperationMenuExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/QuickOperationMenuExtension.cs
@@ -80,7 +80,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				if (view is StackPanel) {
 					var ch = new MenuItem() {Header = "Change Orientation"};
 					_menu.AddSubMenuInTheHeader(ch);
-					setValue = this.ExtendedItem.Properties[StackPanel.OrientationProperty].ValueOnInstance.ToString();
+					setValue = this.ExtendedItem.Properties[StackPanel.OrientationProperty].GetValueOnInstance<object>().ToString();
 					_menu.AddSubMenuCheckable(ch, Enum.GetValues(typeof (Orientation)), Orientation.Vertical.ToString(), setValue);
 					_menu.MainHeader.Items.Add(new Separator());
 					menuItemsAdded++;
@@ -89,7 +89,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				if(this.ExtendedItem.Parent!=null && this.ExtendedItem.Parent.View is DockPanel) {
 					var sda = new MenuItem() {Header = "Set Dock to"};
 					_menu.AddSubMenuInTheHeader(sda);
-					setValue = this.ExtendedItem.Properties.GetAttachedProperty(DockPanel.DockProperty).ValueOnInstance.ToString();
+					setValue = this.ExtendedItem.Properties.GetAttachedProperty(DockPanel.DockProperty).GetValueOnInstance<object>().ToString();
 					_menu.AddSubMenuCheckable(sda, Enum.GetValues(typeof (Dock)), Dock.Left.ToString(), setValue);
 					_menu.MainHeader.Items.Add(new Separator());
 					menuItemsAdded++;
@@ -97,13 +97,13 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 
 				var ha = new MenuItem() {Header = "Horizontal Alignment"};
 				_menu.AddSubMenuInTheHeader(ha);
-				setValue = this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].ValueOnInstance.ToString();
+				setValue = this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<object>().ToString();
 				_menu.AddSubMenuCheckable(ha, Enum.GetValues(typeof (HorizontalAlignment)), HorizontalAlignment.Stretch.ToString(), setValue);
 				menuItemsAdded++;
 
 				var va = new MenuItem() {Header = "Vertical Alignment"};
 				_menu.AddSubMenuInTheHeader(va);
-				setValue = this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].ValueOnInstance.ToString();
+				setValue = this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<object>().ToString();
 				_menu.AddSubMenuCheckable(va, Enum.GetValues(typeof (VerticalAlignment)), VerticalAlignment.Stretch.ToString(), setValue);
 				menuItemsAdded++;
 			}

--- a/WpfDesign.Designer/Project/Extensions/QuickOperationMenuExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/QuickOperationMenuExtension.cs
@@ -80,7 +80,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				if (view is StackPanel) {
 					var ch = new MenuItem() {Header = "Change Orientation"};
 					_menu.AddSubMenuInTheHeader(ch);
-					setValue = this.ExtendedItem.Properties[StackPanel.OrientationProperty].GetValueOnInstance<object>().ToString();
+					setValue = this.ExtendedItem.Properties[StackPanel.OrientationProperty].GetConvertedValueOnInstance<object>().ToString();
 					_menu.AddSubMenuCheckable(ch, Enum.GetValues(typeof (Orientation)), Orientation.Vertical.ToString(), setValue);
 					_menu.MainHeader.Items.Add(new Separator());
 					menuItemsAdded++;
@@ -89,7 +89,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 				if(this.ExtendedItem.Parent!=null && this.ExtendedItem.Parent.View is DockPanel) {
 					var sda = new MenuItem() {Header = "Set Dock to"};
 					_menu.AddSubMenuInTheHeader(sda);
-					setValue = this.ExtendedItem.Properties.GetAttachedProperty(DockPanel.DockProperty).GetValueOnInstance<object>().ToString();
+					setValue = this.ExtendedItem.Properties.GetAttachedProperty(DockPanel.DockProperty).GetConvertedValueOnInstance<object>().ToString();
 					_menu.AddSubMenuCheckable(sda, Enum.GetValues(typeof (Dock)), Dock.Left.ToString(), setValue);
 					_menu.MainHeader.Items.Add(new Separator());
 					menuItemsAdded++;
@@ -97,13 +97,13 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 
 				var ha = new MenuItem() {Header = "Horizontal Alignment"};
 				_menu.AddSubMenuInTheHeader(ha);
-				setValue = this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<object>().ToString();
+				setValue = this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetConvertedValueOnInstance<object>().ToString();
 				_menu.AddSubMenuCheckable(ha, Enum.GetValues(typeof (HorizontalAlignment)), HorizontalAlignment.Stretch.ToString(), setValue);
 				menuItemsAdded++;
 
 				var va = new MenuItem() {Header = "Vertical Alignment"};
 				_menu.AddSubMenuInTheHeader(va);
-				setValue = this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<object>().ToString();
+				setValue = this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetConvertedValueOnInstance<object>().ToString();
 				_menu.AddSubMenuCheckable(va, Enum.GetValues(typeof (VerticalAlignment)), VerticalAlignment.Stretch.ToString(), setValue);
 				menuItemsAdded++;
 			}

--- a/WpfDesign.Designer/Project/Extensions/RenderTransformOriginExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/RenderTransformOriginExtension.cs
@@ -90,7 +90,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			this.ExtendedItem.PropertyChanged += OnPropertyChanged;
 			
 			if (this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).IsSet) {
-				renderTransformOrigin = this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).GetValueOnInstance<Point>();
+				renderTransformOrigin = this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).GetConvertedValueOnInstance<Point>();
 			}
 			
 			AdornerPanel.SetPlacement(renderTransformOriginThumb,
@@ -104,7 +104,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		{
 			var pRel = renderTransformOrigin;
 			if (this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).IsSet)
-				pRel = this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).GetValueOnInstance<Point>();
+				pRel = this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).GetConvertedValueOnInstance<Point>();
 						
 			AdornerPanel.SetPlacement(renderTransformOriginThumb,
 			                          new RelativePlacement(HorizontalAlignment.Left, VerticalAlignment.Top){ XRelativeToContentWidth = pRel.X, YRelativeToContentHeight = pRel.Y });

--- a/WpfDesign.Designer/Project/Extensions/RenderTransformOriginExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/RenderTransformOriginExtension.cs
@@ -90,7 +90,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			this.ExtendedItem.PropertyChanged += OnPropertyChanged;
 			
 			if (this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).IsSet) {
-				renderTransformOrigin = (Point)this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).ValueOnInstance;
+				renderTransformOrigin = this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).GetValueOnInstance<Point>();
 			}
 			
 			AdornerPanel.SetPlacement(renderTransformOriginThumb,
@@ -104,7 +104,7 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 		{
 			var pRel = renderTransformOrigin;
 			if (this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).IsSet)
-				pRel = (Point)this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).ValueOnInstance;
+				pRel = this.ExtendedItem.Properties.GetProperty(FrameworkElement.RenderTransformOriginProperty).GetValueOnInstance<Point>();
 						
 			AdornerPanel.SetPlacement(renderTransformOriginThumb,
 			                          new RelativePlacement(HorizontalAlignment.Left, VerticalAlignment.Top){ XRelativeToContentWidth = pRel.X, YRelativeToContentHeight = pRel.Y });

--- a/WpfDesign.Designer/Project/Extensions/ResizeThumbExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/ResizeThumbExtension.cs
@@ -162,8 +162,8 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			var newHeight = Math.Max(0, oldSize.Height + dy);
 
 			if (operation.CurrentContainerBehavior is GridPlacementSupport) {
-				var hor = this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
-				var ver = this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
+				var hor = this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetConvertedValueOnInstance<HorizontalAlignment>();
+				var ver = this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetConvertedValueOnInstance<VerticalAlignment>();
 				if (hor == HorizontalAlignment.Stretch)
 					this.ExtendedItem.Properties[FrameworkElement.WidthProperty].Reset();
 				else

--- a/WpfDesign.Designer/Project/Extensions/ResizeThumbExtension.cs
+++ b/WpfDesign.Designer/Project/Extensions/ResizeThumbExtension.cs
@@ -162,8 +162,8 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 			var newHeight = Math.Max(0, oldSize.Height + dy);
 
 			if (operation.CurrentContainerBehavior is GridPlacementSupport) {
-				var hor = (HorizontalAlignment) this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].ValueOnInstance;
-				var ver = (VerticalAlignment) this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].ValueOnInstance;
+				var hor = this.ExtendedItem.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>();
+				var ver = this.ExtendedItem.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>();
 				if (hor == HorizontalAlignment.Stretch)
 					this.ExtendedItem.Properties[FrameworkElement.WidthProperty].Reset();
 				else

--- a/WpfDesign.Designer/Project/ModelTools.cs
+++ b/WpfDesign.Designer/Project/ModelTools.cs
@@ -508,7 +508,7 @@ namespace ICSharpCode.WpfDesign.Designer
 			transformProperty = transformProperty ?? FrameworkElement.RenderTransformProperty;
 			Transform oldTransform = null;
 			if (designItem.Properties.GetProperty(transformProperty).IsSet) {
-				oldTransform = designItem.Properties.GetProperty(transformProperty).GetValueOnInstance<Transform>();
+				oldTransform = designItem.Properties.GetProperty(transformProperty).GetConvertedValueOnInstance<Transform>();
 			}
 			
 			if (oldTransform is MatrixTransform) {
@@ -675,16 +675,16 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
+								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetConvertedValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
 								{
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Left = xmin;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualWidth - (xmin + (double)((FrameworkElement)item.Component).ActualWidth);
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Right = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -711,9 +711,9 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
+								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetConvertedValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
 								{
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Left = mpos - (((FrameworkElement)item.Component).ActualWidth) / 2;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -721,7 +721,7 @@ namespace ICSharpCode.WpfDesign.Designer
 								{
 									var pp = mpos - (((FrameworkElement)item.Component).ActualWidth) / 2;
 									var pos = (double)((Panel)item.Parent.Component).ActualWidth - pp - (((FrameworkElement)item.Component).ActualWidth);
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Right = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -745,17 +745,17 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
+								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetConvertedValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
 								{
 									var pos = xmax - (double)((FrameworkElement)item.Component).ActualWidth;
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Left = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualWidth - xmax;
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Right = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -778,17 +778,17 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
+								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetConvertedValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
 								{
 									item.Properties.GetAttachedProperty(Canvas.TopProperty).SetValue(ymin);
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Top = ymin;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualHeight - (ymin + (double)((FrameworkElement)item.Component).ActualHeight);
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Bottom = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -812,9 +812,9 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
+								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetConvertedValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
 								{
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Top = ympos - (((FrameworkElement)item.Component).ActualHeight) / 2;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -822,7 +822,7 @@ namespace ICSharpCode.WpfDesign.Designer
 								{
 									var pp = mpos - (((FrameworkElement)item.Component).ActualHeight) / 2;
 									var pos = (double)((Panel)item.Parent.Component).ActualHeight - pp - (((FrameworkElement)item.Component).ActualHeight);
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Bottom = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -846,17 +846,17 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
+								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetConvertedValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
 								{
 									var pos = ymax - (double)((FrameworkElement)item.Component).ActualHeight;
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Top = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualHeight - ymax;
-									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetConvertedValueOnInstance<Thickness>();
 									margin.Bottom = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}

--- a/WpfDesign.Designer/Project/ModelTools.cs
+++ b/WpfDesign.Designer/Project/ModelTools.cs
@@ -508,7 +508,7 @@ namespace ICSharpCode.WpfDesign.Designer
 			transformProperty = transformProperty ?? FrameworkElement.RenderTransformProperty;
 			Transform oldTransform = null;
 			if (designItem.Properties.GetProperty(transformProperty).IsSet) {
-				oldTransform = designItem.Properties.GetProperty(transformProperty).ValueOnInstance as Transform;
+				oldTransform = designItem.Properties.GetProperty(transformProperty).GetValueOnInstance<Transform>();
 			}
 			
 			if (oldTransform is MatrixTransform) {
@@ -675,7 +675,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if ((HorizontalAlignment)item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance != HorizontalAlignment.Right)
+								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
 								{
 									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Left = xmin;
@@ -711,7 +711,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if ((HorizontalAlignment)item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance != HorizontalAlignment.Right)
+								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
 								{
 									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Left = mpos - (((FrameworkElement)item.Component).ActualWidth) / 2;
@@ -745,7 +745,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if ((HorizontalAlignment)item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance != HorizontalAlignment.Right)
+								if (item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).GetValueOnInstance<HorizontalAlignment>() != HorizontalAlignment.Right)
 								{
 									var pos = xmax - (double)((FrameworkElement)item.Component).ActualWidth;
 									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
@@ -778,7 +778,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if ((VerticalAlignment)item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance != VerticalAlignment.Bottom)
+								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
 								{
 									item.Properties.GetAttachedProperty(Canvas.TopProperty).SetValue(ymin);
 									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
@@ -812,7 +812,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if ((VerticalAlignment)item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance != VerticalAlignment.Bottom)
+								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
 								{
 									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Top = ympos - (((FrameworkElement)item.Component).ActualHeight) / 2;
@@ -846,7 +846,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							}
 							else if (container.Component is Grid)
 							{
-								if ((VerticalAlignment)item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance != VerticalAlignment.Bottom)
+								if (item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).GetValueOnInstance<VerticalAlignment>() != VerticalAlignment.Bottom)
 								{
 									var pos = ymax - (double)((FrameworkElement)item.Component).ActualHeight;
 									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();

--- a/WpfDesign.Designer/Project/ModelTools.cs
+++ b/WpfDesign.Designer/Project/ModelTools.cs
@@ -677,14 +677,14 @@ namespace ICSharpCode.WpfDesign.Designer
 							{
 								if ((HorizontalAlignment)item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance != HorizontalAlignment.Right)
 								{
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Left = xmin;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualWidth - (xmin + (double)((FrameworkElement)item.Component).ActualWidth);
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Right = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -713,7 +713,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							{
 								if ((HorizontalAlignment)item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance != HorizontalAlignment.Right)
 								{
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Left = mpos - (((FrameworkElement)item.Component).ActualWidth) / 2;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -721,7 +721,7 @@ namespace ICSharpCode.WpfDesign.Designer
 								{
 									var pp = mpos - (((FrameworkElement)item.Component).ActualWidth) / 2;
 									var pos = (double)((Panel)item.Parent.Component).ActualWidth - pp - (((FrameworkElement)item.Component).ActualWidth);
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Right = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -748,14 +748,14 @@ namespace ICSharpCode.WpfDesign.Designer
 								if ((HorizontalAlignment)item.Properties.GetProperty(FrameworkElement.HorizontalAlignmentProperty).ValueOnInstance != HorizontalAlignment.Right)
 								{
 									var pos = xmax - (double)((FrameworkElement)item.Component).ActualWidth;
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Left = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualWidth - xmax;
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Right = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -781,14 +781,14 @@ namespace ICSharpCode.WpfDesign.Designer
 								if ((VerticalAlignment)item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance != VerticalAlignment.Bottom)
 								{
 									item.Properties.GetAttachedProperty(Canvas.TopProperty).SetValue(ymin);
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Top = ymin;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualHeight - (ymin + (double)((FrameworkElement)item.Component).ActualHeight);
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Bottom = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -814,7 +814,7 @@ namespace ICSharpCode.WpfDesign.Designer
 							{
 								if ((VerticalAlignment)item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance != VerticalAlignment.Bottom)
 								{
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Top = ympos - (((FrameworkElement)item.Component).ActualHeight) / 2;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -822,7 +822,7 @@ namespace ICSharpCode.WpfDesign.Designer
 								{
 									var pp = mpos - (((FrameworkElement)item.Component).ActualHeight) / 2;
 									var pos = (double)((Panel)item.Parent.Component).ActualHeight - pp - (((FrameworkElement)item.Component).ActualHeight);
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Bottom = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
@@ -849,14 +849,14 @@ namespace ICSharpCode.WpfDesign.Designer
 								if ((VerticalAlignment)item.Properties.GetProperty(FrameworkElement.VerticalAlignmentProperty).ValueOnInstance != VerticalAlignment.Bottom)
 								{
 									var pos = ymax - (double)((FrameworkElement)item.Component).ActualHeight;
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Top = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}
 								else
 								{
 									var pos = (double)((Panel)item.Parent.Component).ActualHeight - ymax;
-									var margin = (Thickness)item.Properties.GetProperty(FrameworkElement.MarginProperty).ValueOnInstance;
+									var margin = item.Properties.GetProperty(FrameworkElement.MarginProperty).GetValueOnInstance<Thickness>();
 									margin.Bottom = pos;
 									item.Properties.GetProperty(FrameworkElement.MarginProperty).SetValue(margin);
 								}

--- a/WpfDesign.Designer/Project/OutlineView/OutlineNodeBase.cs
+++ b/WpfDesign.Designer/Project/OutlineView/OutlineNodeBase.cs
@@ -55,7 +55,7 @@ namespace ICSharpCode.WpfDesign.Designer.OutlineView
 			bool hidden = false;
 			try
 			{
-				hidden = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsHiddenProperty).ValueOnInstance, true);
+				hidden = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsHiddenProperty).GetValueOnInstance<bool>(), true);
 			}
 			catch (Exception)
 			{ }
@@ -66,7 +66,7 @@ namespace ICSharpCode.WpfDesign.Designer.OutlineView
 			bool locked = false;
 			try
 			{
-				locked = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).ValueOnInstance, true);
+				locked = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).GetValueOnInstance<bool>(), true);
 			}
 			catch (Exception)
 			{ }

--- a/WpfDesign.Designer/Project/OutlineView/OutlineNodeBase.cs
+++ b/WpfDesign.Designer/Project/OutlineView/OutlineNodeBase.cs
@@ -55,7 +55,7 @@ namespace ICSharpCode.WpfDesign.Designer.OutlineView
 			bool hidden = false;
 			try
 			{
-				hidden = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsHiddenProperty).GetValueOnInstance<bool>(), true);
+				hidden = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsHiddenProperty).GetConvertedValueOnInstance<bool>(), true);
 			}
 			catch (Exception)
 			{ }
@@ -66,7 +66,7 @@ namespace ICSharpCode.WpfDesign.Designer.OutlineView
 			bool locked = false;
 			try
 			{
-				locked = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).GetValueOnInstance<bool>(), true);
+				locked = object.Equals(designItem.Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).GetConvertedValueOnInstance<bool>(), true);
 			}
 			catch (Exception)
 			{ }

--- a/WpfDesign.Designer/Project/Xaml/XamlDesignItem.cs
+++ b/WpfDesign.Designer/Project/Xaml/XamlDesignItem.cs
@@ -98,7 +98,7 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 		{
 			if (!string.IsNullOrEmpty(oldName) && !string.IsNullOrEmpty(newName)) {
 				var root = GetRootXamlObject(this.XamlObject);
-				var references = GetAllChildXamlObjects(root).Where(x => x.ElementType == typeof(Reference) && Equals(x.FindOrCreateProperty("Name").ValueOnInstance, oldName));
+				var references = GetAllChildXamlObjects(root).Where(x => x.ElementType == typeof(Reference) && Equals(x.FindOrCreateProperty("Name").GetValueOnInstance<string>(), oldName));
 				foreach (var designItem in references)
 				{
 					var property = designItem.FindOrCreateProperty("Name");
@@ -108,7 +108,7 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 				}
 
 				root = GetRootXamlObject(this.XamlObject, true);
-				var bindings = GetAllChildXamlObjects(root, true).Where(x => x.ElementType == typeof(Binding) && Equals(x.FindOrCreateProperty("ElementName").ValueOnInstance, oldName));
+				var bindings = GetAllChildXamlObjects(root, true).Where(x => x.ElementType == typeof(Binding) && Equals(x.FindOrCreateProperty("ElementName").GetValueOnInstance<string>(), oldName));
 				foreach (var designItem in bindings)
 				{
 					var property = designItem.FindOrCreateProperty("ElementName");
@@ -283,7 +283,7 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 		/// </summary>
 		public bool IsDesignTimeLocked {
 			get {
-				var locked = Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).ValueOnInstance;
+				var locked = Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).GetValueOnInstance<object>();
 				return (locked != null && (bool) locked == true);
 			}
 			set {

--- a/WpfDesign.Designer/Project/Xaml/XamlDesignItem.cs
+++ b/WpfDesign.Designer/Project/Xaml/XamlDesignItem.cs
@@ -283,7 +283,7 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 		/// </summary>
 		public bool IsDesignTimeLocked {
 			get {
-				var locked = Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).GetValueOnInstance<object>();
+				var locked = Properties.GetAttachedProperty(DesignTimeProperties.IsLockedProperty).GetConvertedValueOnInstance<object>();
 				return (locked != null && (bool) locked == true);
 			}
 			set {

--- a/WpfDesign.Designer/Project/Xaml/XamlEditOperations.cs
+++ b/WpfDesign.Designer/Project/Xaml/XamlEditOperations.cs
@@ -220,7 +220,7 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 		/// <param name="pastedItems">The list of elements to be added</param>
 		static void AddInParent(DesignItem parent,IList<DesignItem> pastedItems)
 		{
-			IEnumerable<Rect> rects = pastedItems.Select(i => new Rect(new Point(0, 0), new Point((double)i.Properties["Width"].ValueOnInstance, (double)i.Properties["Height"].ValueOnInstance)));
+			IEnumerable<Rect> rects = pastedItems.Select(i => new Rect(new Point(0, 0), new Point(i.Properties["Width"].GetValueOnInstance<double>(), i.Properties["Height"].GetValueOnInstance<double>())));
 			var operation = PlacementOperation.TryStartInsertNewComponents(parent, pastedItems, rects.ToList(), PlacementType.PasteItem);
 			ISelectionService selection = parent.Services.DesignPanel.Context.Services.Selection;
 			selection.SetSelectedComponents(pastedItems);

--- a/WpfDesign.Designer/Project/Xaml/XamlEditOperations.cs
+++ b/WpfDesign.Designer/Project/Xaml/XamlEditOperations.cs
@@ -220,7 +220,7 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 		/// <param name="pastedItems">The list of elements to be added</param>
 		static void AddInParent(DesignItem parent,IList<DesignItem> pastedItems)
 		{
-			IEnumerable<Rect> rects = pastedItems.Select(i => new Rect(new Point(0, 0), new Point(i.Properties["Width"].GetValueOnInstance<double>(), i.Properties["Height"].GetValueOnInstance<double>())));
+			IEnumerable<Rect> rects = pastedItems.Select(i => new Rect(new Point(0, 0), new Point(i.Properties["Width"].GetConvertedValueOnInstance<double>(), i.Properties["Height"].GetConvertedValueOnInstance<double>())));
 			var operation = PlacementOperation.TryStartInsertNewComponents(parent, pastedItems, rects.ToList(), PlacementType.PasteItem);
 			ISelectionService selection = parent.Services.DesignPanel.Context.Services.Selection;
 			selection.SetSelectedComponents(pastedItems);

--- a/WpfDesign.Designer/Project/Xaml/XamlModelProperty.cs
+++ b/WpfDesign.Designer/Project/Xaml/XamlModelProperty.cs
@@ -271,7 +271,7 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 			}
 		}
 
-		public override T GetValueOnInstance<T>() => _property.GetValueOnInstance<T>();
+		public override T GetConvertedValueOnInstance<T>() => _property.GetValueOnInstance<T>();
 
 		public sealed class PropertyChangeAction : ITransactionItem
 		{

--- a/WpfDesign.Designer/Project/Xaml/XamlModelProperty.cs
+++ b/WpfDesign.Designer/Project/Xaml/XamlModelProperty.cs
@@ -270,7 +270,9 @@ namespace ICSharpCode.WpfDesign.Designer.Xaml
 				_designItem.NotifyPropertyChanged(this, oldValue, null);
 			}
 		}
-		
+
+		public override T GetValueOnInstance<T>() => _property.GetValueOnInstance<T>();
+
 		public sealed class PropertyChangeAction : ITransactionItem
 		{
 			readonly XamlModelProperty property;

--- a/WpfDesign.Designer/Tests/Designer/ModelTests.cs
+++ b/WpfDesign.Designer/Tests/Designer/ModelTests.cs
@@ -82,7 +82,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 		public void ButtonClickEventHandler()
 		{
 			DesignItem button = CreateCanvasContext("<Button Click='OnClick'/>");
-			Assert.AreEqual("OnClick", button.Properties["Click"].GetValueOnInstance<string>());
+			Assert.AreEqual("OnClick", button.Properties["Click"].GetConvertedValueOnInstance<string>());
 			
 			button.Properties["Click"].Reset();
 			button.Properties["KeyDown"].SetValue("ButtonKeyDown");
@@ -219,7 +219,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithList, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			otherListProp = button.Properties["Tag"].Value.Properties["OtherList"];
-			Assert.IsTrue(otherListProp.GetValueOnInstance<XamlDom.ExampleClassList>().Count == otherListProp.CollectionElements.Count);
+			Assert.IsTrue(otherListProp.GetConvertedValueOnInstance<XamlDom.ExampleClassList>().Count == otherListProp.CollectionElements.Count);
 			
 			s.Undo();
 			Assert.IsFalse(s.CanUndo);
@@ -232,7 +232,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithList, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			otherListProp = button.Properties["Tag"].Value.Properties["OtherList"];
-			Assert.IsTrue(otherListProp.GetValueOnInstance<XamlDom.ExampleClassList>().Count == otherListProp.CollectionElements.Count);
+			Assert.IsTrue(otherListProp.GetConvertedValueOnInstance<XamlDom.ExampleClassList>().Count == otherListProp.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -306,7 +306,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithDictionary, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			dictionaryProp = button.Properties["Tag"].Value.Properties["Dictionary"];
-			Assert.IsTrue(dictionaryProp.GetValueOnInstance<XamlDom.ExampleClassDictionary>().Count == dictionaryProp.CollectionElements.Count);
+			Assert.IsTrue(dictionaryProp.GetConvertedValueOnInstance<XamlDom.ExampleClassDictionary>().Count == dictionaryProp.CollectionElements.Count);
 			
 			s.Undo();
 			Assert.IsFalse(s.CanUndo);
@@ -319,7 +319,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithDictionary, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			dictionaryProp = button.Properties["Tag"].Value.Properties["Dictionary"];
-			Assert.IsTrue(dictionaryProp.GetValueOnInstance<XamlDom.ExampleClassDictionary>().Count == dictionaryProp.CollectionElements.Count);
+			Assert.IsTrue(dictionaryProp.GetConvertedValueOnInstance<XamlDom.ExampleClassDictionary>().Count == dictionaryProp.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -361,7 +361,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXaml, textBlock.Context);
 			
 			inputbinding = textBlock.Properties["InputBindings"];
-			Assert.IsTrue(inputbinding.GetValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
+			Assert.IsTrue(inputbinding.GetConvertedValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
 			
 			s.Undo();
 			Assert.IsFalse(s.CanUndo);
@@ -373,7 +373,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			Assert.IsFalse(s.CanRedo);
 			AssertCanvasDesignerOutput(expectedXaml, textBlock.Context);
 			
-			Assert.IsTrue(inputbinding.GetValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
+			Assert.IsTrue(inputbinding.GetConvertedValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -450,7 +450,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			Assert.IsFalse(s.CanRedo);
 			AssertCanvasDesignerOutput(expectedXaml, textBlock.Context);
 			
-			Assert.IsTrue(inputbinding.GetValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
+			Assert.IsTrue(inputbinding.GetConvertedValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -643,7 +643,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			exampleClassItem.Properties["StringProp"].SetValue("String value");
 			otherListProp.CollectionElements.Add(exampleClassItem);
 			
-			var listInstance = otherListProp.GetValueOnInstance<XamlDom.ExampleClassList>();
+			var listInstance = otherListProp.GetConvertedValueOnInstance<XamlDom.ExampleClassList>();
 			Assert.AreEqual(1, listInstance.Count);
 			Assert.AreEqual(1, otherListProp.CollectionElements.Count);
 			
@@ -680,7 +680,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			exampleClassItem.Properties["StringProp"].SetValue("String value");
 			dictionaryProp.CollectionElements.Add(exampleClassItem);
 			
-			var dictionaryInstance = dictionaryProp.GetValueOnInstance<XamlDom.ExampleClassDictionary>();
+			var dictionaryInstance = dictionaryProp.GetConvertedValueOnInstance<XamlDom.ExampleClassDictionary>();
 			Assert.AreEqual(1, dictionaryInstance.Count);
 			Assert.AreEqual(1, dictionaryProp.CollectionElements.Count);
 			
@@ -1045,7 +1045,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			var sourceProp = image.Properties[Image.SourceProperty];
 			
 			Assert.IsNull(sourceProp.ValueOnInstance);
-			Assert.IsNull(sourceProp.GetValueOnInstance<object>());
+			Assert.IsNull(sourceProp.GetConvertedValueOnInstance<object>());
 			Assert.IsNull(sourceProp.Value);
 			Assert.IsNotNull(sourceProp.TextValue);
 			Assert.AreEqual(sourceTextValue, sourceProp.TextValue);

--- a/WpfDesign.Designer/Tests/Designer/ModelTests.cs
+++ b/WpfDesign.Designer/Tests/Designer/ModelTests.cs
@@ -24,6 +24,7 @@ using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Xml;
 
@@ -81,7 +82,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 		public void ButtonClickEventHandler()
 		{
 			DesignItem button = CreateCanvasContext("<Button Click='OnClick'/>");
-			Assert.AreEqual("OnClick", button.Properties["Click"].ValueOnInstance);
+			Assert.AreEqual("OnClick", button.Properties["Click"].GetValueOnInstance<string>());
 			
 			button.Properties["Click"].Reset();
 			button.Properties["KeyDown"].SetValue("ButtonKeyDown");
@@ -218,7 +219,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithList, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			otherListProp = button.Properties["Tag"].Value.Properties["OtherList"];
-			Assert.IsTrue(((ICSharpCode.WpfDesign.Tests.XamlDom.ExampleClassList)otherListProp.ValueOnInstance).Count == otherListProp.CollectionElements.Count);
+			Assert.IsTrue(otherListProp.GetValueOnInstance<XamlDom.ExampleClassList>().Count == otherListProp.CollectionElements.Count);
 			
 			s.Undo();
 			Assert.IsFalse(s.CanUndo);
@@ -231,7 +232,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithList, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			otherListProp = button.Properties["Tag"].Value.Properties["OtherList"];
-			Assert.IsTrue(((ICSharpCode.WpfDesign.Tests.XamlDom.ExampleClassList)otherListProp.ValueOnInstance).Count == otherListProp.CollectionElements.Count);
+			Assert.IsTrue(otherListProp.GetValueOnInstance<XamlDom.ExampleClassList>().Count == otherListProp.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -305,7 +306,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithDictionary, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			dictionaryProp = button.Properties["Tag"].Value.Properties["Dictionary"];
-			Assert.IsTrue(((ICSharpCode.WpfDesign.Tests.XamlDom.ExampleClassDictionary)dictionaryProp.ValueOnInstance).Count == dictionaryProp.CollectionElements.Count);
+			Assert.IsTrue(dictionaryProp.GetValueOnInstance<XamlDom.ExampleClassDictionary>().Count == dictionaryProp.CollectionElements.Count);
 			
 			s.Undo();
 			Assert.IsFalse(s.CanUndo);
@@ -318,7 +319,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXamlWithDictionary, button.Context, "xmlns:Controls0=\"" + ICSharpCode.WpfDesign.Tests.XamlDom.XamlTypeFinderTests.XamlDomTestsNamespace + "\"");
 			
 			dictionaryProp = button.Properties["Tag"].Value.Properties["Dictionary"];
-			Assert.IsTrue(((ICSharpCode.WpfDesign.Tests.XamlDom.ExampleClassDictionary)dictionaryProp.ValueOnInstance).Count == dictionaryProp.CollectionElements.Count);
+			Assert.IsTrue(dictionaryProp.GetValueOnInstance<XamlDom.ExampleClassDictionary>().Count == dictionaryProp.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -360,7 +361,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			AssertCanvasDesignerOutput(expectedXaml, textBlock.Context);
 			
 			inputbinding = textBlock.Properties["InputBindings"];
-			Assert.IsTrue(((System.Windows.Input.InputBindingCollection)inputbinding.ValueOnInstance).Count == inputbinding.CollectionElements.Count);
+			Assert.IsTrue(inputbinding.GetValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
 			
 			s.Undo();
 			Assert.IsFalse(s.CanUndo);
@@ -372,7 +373,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			Assert.IsFalse(s.CanRedo);
 			AssertCanvasDesignerOutput(expectedXaml, textBlock.Context);
 			
-			Assert.IsTrue(((System.Windows.Input.InputBindingCollection)inputbinding.ValueOnInstance).Count == inputbinding.CollectionElements.Count);
+			Assert.IsTrue(inputbinding.GetValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -449,7 +450,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			Assert.IsFalse(s.CanRedo);
 			AssertCanvasDesignerOutput(expectedXaml, textBlock.Context);
 			
-			Assert.IsTrue(((System.Windows.Input.InputBindingCollection)inputbinding.ValueOnInstance).Count == inputbinding.CollectionElements.Count);
+			Assert.IsTrue(inputbinding.GetValueOnInstance<InputBindingCollection>().Count == inputbinding.CollectionElements.Count);
 			
 			AssertLog("");
 		}
@@ -642,7 +643,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			exampleClassItem.Properties["StringProp"].SetValue("String value");
 			otherListProp.CollectionElements.Add(exampleClassItem);
 			
-			var listInstance = (ICSharpCode.WpfDesign.Tests.XamlDom.ExampleClassList)otherListProp.ValueOnInstance;
+			var listInstance = otherListProp.GetValueOnInstance<XamlDom.ExampleClassList>();
 			Assert.AreEqual(1, listInstance.Count);
 			Assert.AreEqual(1, otherListProp.CollectionElements.Count);
 			
@@ -679,7 +680,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			exampleClassItem.Properties["StringProp"].SetValue("String value");
 			dictionaryProp.CollectionElements.Add(exampleClassItem);
 			
-			var dictionaryInstance = (ICSharpCode.WpfDesign.Tests.XamlDom.ExampleClassDictionary)dictionaryProp.ValueOnInstance;
+			var dictionaryInstance = dictionaryProp.GetValueOnInstance<XamlDom.ExampleClassDictionary>();
 			Assert.AreEqual(1, dictionaryInstance.Count);
 			Assert.AreEqual(1, dictionaryProp.CollectionElements.Count);
 			
@@ -1044,6 +1045,7 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 			var sourceProp = image.Properties[Image.SourceProperty];
 			
 			Assert.IsNull(sourceProp.ValueOnInstance);
+			Assert.IsNull(sourceProp.GetValueOnInstance<object>());
 			Assert.IsNull(sourceProp.Value);
 			Assert.IsNotNull(sourceProp.TextValue);
 			Assert.AreEqual(sourceTextValue, sourceProp.TextValue);

--- a/WpfDesign.Designer/Tests/Designer/PlacementTests.cs
+++ b/WpfDesign.Designer/Tests/Designer/PlacementTests.cs
@@ -85,59 +85,59 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 		[Test]
 		public void AssertAlignmentsForAutoSize()
 		{
-			Assert.AreEqual(HorizontalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.HorizontalAlignmentProperty].ValueOnInstance);
-			Assert.AreEqual(VerticalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.VerticalAlignmentProperty].ValueOnInstance);
+			Assert.AreEqual(HorizontalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>());
+			Assert.AreEqual(VerticalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>());
 		}
 		
 		[Test]
 		public void AssertAlignmentForFixedSize()
 		{
-			Assert.AreEqual(HorizontalAlignment.Left,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HorizontalAlignmentProperty].ValueOnInstance);
-			Assert.AreEqual(VerticalAlignment.Top,_buttonIsGridWithFixedSize.Properties[FrameworkElement.VerticalAlignmentProperty].ValueOnInstance);
+			Assert.AreEqual(HorizontalAlignment.Left,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>());
+			Assert.AreEqual(VerticalAlignment.Top,_buttonIsGridWithFixedSize.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>());
 		}
 		
 		[Test]
 		public void AssertMarginForAutoSize()
 		{
-			Assert.AreEqual(new Thickness(50,25,-50,-25),_buttonInGridWithAutoSize.Properties[FrameworkElement.MarginProperty].ValueOnInstance);
+			Assert.AreEqual(new Thickness(50,25,-50,-25),_buttonInGridWithAutoSize.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>());
 		}
 		
 		[Test]
 		public void AssertMarginForFixedSize()
 		{
-			Assert.AreEqual(new Thickness(50,25,0,0),_buttonIsGridWithFixedSize.Properties[FrameworkElement.MarginProperty].ValueOnInstance);
+			Assert.AreEqual(new Thickness(50,25,0,0),_buttonIsGridWithFixedSize.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>());
 		}
 		
 		[Test]
 		public void AssertRowColumnForAutoSize()
 		{
-			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowProperty).ValueOnInstance);
-			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).ValueOnInstance);
-			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnProperty).ValueOnInstance);
-			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).ValueOnInstance);
+			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetValueOnInstance<int>());
 		}
 		
 		[Test]
 		public void AssetRowColumnForFixedSize()
 		{
-			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowProperty).ValueOnInstance);
-			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).ValueOnInstance);
-			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnProperty).ValueOnInstance);
-			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).ValueOnInstance);
+			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetValueOnInstance<int>());
 		}
 		
 		[Test]
 		public void AssertSizeForAutoSize()
 		{
-			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.HeightProperty].ValueOnInstance);
-			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.WidthProperty].ValueOnInstance);
+			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.HeightProperty].GetValueOnInstance<double>());
+			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.WidthProperty].GetValueOnInstance<double>());
 		}
 		
 		[Test]
 		public void AssertSizeForFixedSize()
 		{
-			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HeightProperty].ValueOnInstance);
-			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.WidthProperty].ValueOnInstance);
+			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HeightProperty].GetValueOnInstance<double>());
+			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.WidthProperty].GetValueOnInstance<double>());
 		}
 		#endregion
 	}

--- a/WpfDesign.Designer/Tests/Designer/PlacementTests.cs
+++ b/WpfDesign.Designer/Tests/Designer/PlacementTests.cs
@@ -85,59 +85,59 @@ namespace ICSharpCode.WpfDesign.Tests.Designer
 		[Test]
 		public void AssertAlignmentsForAutoSize()
 		{
-			Assert.AreEqual(HorizontalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>());
-			Assert.AreEqual(VerticalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>());
+			Assert.AreEqual(HorizontalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.HorizontalAlignmentProperty].GetConvertedValueOnInstance<HorizontalAlignment>());
+			Assert.AreEqual(VerticalAlignment.Stretch,_buttonInGridWithAutoSize.Properties[FrameworkElement.VerticalAlignmentProperty].GetConvertedValueOnInstance<VerticalAlignment>());
 		}
 		
 		[Test]
 		public void AssertAlignmentForFixedSize()
 		{
-			Assert.AreEqual(HorizontalAlignment.Left,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HorizontalAlignmentProperty].GetValueOnInstance<HorizontalAlignment>());
-			Assert.AreEqual(VerticalAlignment.Top,_buttonIsGridWithFixedSize.Properties[FrameworkElement.VerticalAlignmentProperty].GetValueOnInstance<VerticalAlignment>());
+			Assert.AreEqual(HorizontalAlignment.Left,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HorizontalAlignmentProperty].GetConvertedValueOnInstance<HorizontalAlignment>());
+			Assert.AreEqual(VerticalAlignment.Top,_buttonIsGridWithFixedSize.Properties[FrameworkElement.VerticalAlignmentProperty].GetConvertedValueOnInstance<VerticalAlignment>());
 		}
 		
 		[Test]
 		public void AssertMarginForAutoSize()
 		{
-			Assert.AreEqual(new Thickness(50,25,-50,-25),_buttonInGridWithAutoSize.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>());
+			Assert.AreEqual(new Thickness(50,25,-50,-25),_buttonInGridWithAutoSize.Properties[FrameworkElement.MarginProperty].GetConvertedValueOnInstance<Thickness>());
 		}
 		
 		[Test]
 		public void AssertMarginForFixedSize()
 		{
-			Assert.AreEqual(new Thickness(50,25,0,0),_buttonIsGridWithFixedSize.Properties[FrameworkElement.MarginProperty].GetValueOnInstance<Thickness>());
+			Assert.AreEqual(new Thickness(50,25,0,0),_buttonIsGridWithFixedSize.Properties[FrameworkElement.MarginProperty].GetConvertedValueOnInstance<Thickness>());
 		}
 		
 		[Test]
 		public void AssertRowColumnForAutoSize()
 		{
-			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowProperty).GetValueOnInstance<int>());
-			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetValueOnInstance<int>());
-			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnProperty).GetValueOnInstance<int>());
-			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowProperty).GetConvertedValueOnInstance<int>());
+			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetConvertedValueOnInstance<int>());
+			Assert.AreEqual(0,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnProperty).GetConvertedValueOnInstance<int>());
+			Assert.AreEqual(1,_buttonInGridWithAutoSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetConvertedValueOnInstance<int>());
 		}
 		
 		[Test]
 		public void AssetRowColumnForFixedSize()
 		{
-			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowProperty).GetValueOnInstance<int>());
-			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetValueOnInstance<int>());
-			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnProperty).GetValueOnInstance<int>());
-			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetValueOnInstance<int>());
+			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowProperty).GetConvertedValueOnInstance<int>());
+			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.RowSpanProperty).GetConvertedValueOnInstance<int>());
+			Assert.AreEqual(0, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnProperty).GetConvertedValueOnInstance<int>());
+			Assert.AreEqual(1, _buttonIsGridWithFixedSize.Properties.GetAttachedProperty(Grid.ColumnSpanProperty).GetConvertedValueOnInstance<int>());
 		}
 		
 		[Test]
 		public void AssertSizeForAutoSize()
 		{
-			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.HeightProperty].GetValueOnInstance<double>());
-			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.WidthProperty].GetValueOnInstance<double>());
+			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.HeightProperty].GetConvertedValueOnInstance<double>());
+			Assert.AreEqual(double.NaN,_buttonInGridWithAutoSize.Properties[FrameworkElement.WidthProperty].GetConvertedValueOnInstance<double>());
 		}
 		
 		[Test]
 		public void AssertSizeForFixedSize()
 		{
-			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HeightProperty].GetValueOnInstance<double>());
-			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.WidthProperty].GetValueOnInstance<double>());
+			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.HeightProperty].GetConvertedValueOnInstance<double>());
+			Assert.AreEqual(50,_buttonIsGridWithFixedSize.Properties[FrameworkElement.WidthProperty].GetConvertedValueOnInstance<double>());
 		}
 		#endregion
 	}

--- a/WpfDesign.XamlDom/Project/XamlProperty.cs
+++ b/WpfDesign.XamlDom/Project/XamlProperty.cs
@@ -705,5 +705,28 @@ namespace ICSharpCode.WpfDesign.XamlDom
 				return attribute == null && element == null;
 			}
 		}*/
+
+		/// <inheritdoc />
+		public T GetValueOnInstance<T>()
+		{
+			var obj = ValueOnInstance;
+
+			if (obj == null)
+			{
+				return default;
+			}
+
+			if (obj is T typed)
+			{
+				return typed;
+			}
+
+			if (TypeConverter.CanConvertTo(typeof(T)))
+			{
+				return (T)TypeConverter.ConvertTo(obj, typeof(T));
+			}
+
+			return (T)obj;
+		}
 	}
 }

--- a/WpfDesign/Project/DesignItemProperty.cs
+++ b/WpfDesign/Project/DesignItemProperty.cs
@@ -132,10 +132,10 @@ namespace ICSharpCode.WpfDesign
 		public abstract void Reset();
 
 		/// <summary>
-		/// Gets the value of the property on the designed instance as an instance of T.
+		/// Gets the value of <see cref="ValueOnInstance"/> as an instance of T (converted using <see cref="TypeConverter"/> if required and the converter is capable).
 		/// If the property is not set, or does not match type T, this returns the default value.
 		/// </summary>
-		public abstract T GetValueOnInstance<T>();
+		public abstract T GetConvertedValueOnInstance<T>();
 
 		/// <summary>
 		/// Gets the parent design item.

--- a/WpfDesign/Project/DesignItemProperty.cs
+++ b/WpfDesign/Project/DesignItemProperty.cs
@@ -132,6 +132,12 @@ namespace ICSharpCode.WpfDesign
 		public abstract void Reset();
 
 		/// <summary>
+		/// Gets the value of the property on the designed instance as an instance of T.
+		/// If the property is not set, or does not match type T, this returns the default value.
+		/// </summary>
+		public abstract T GetValueOnInstance<T>();
+
+		/// <summary>
 		/// Gets the parent design item.
 		/// </summary>
 		public abstract DesignItem DesignItem { get; }


### PR DESCRIPTION
Added GetValueOnInstance&lt;T&gt;() on DesignItemProperty.cs implemented in XamlProperty.cs that uses the TypeConverter when available before doing a direct cast.

This allows users to replace properties on FrameworkElement deratives, e.g. 
`
public new ScriptableThickness Margin { get; set; ]
`
as long as they provide a matching TypeConverter that can convert to the original type, Thickness in this case.