### PR TITLE
Fixed a NullReferenceException caused by handling a left mouse click on a child node

### DIFF
--- a/WpfDesign.Designer/Project/OutlineView/OutlineTreeView.cs
+++ b/WpfDesign.Designer/Project/OutlineView/OutlineTreeView.cs
@@ -56,10 +56,8 @@ namespace ICSharpCode.WpfDesign.Designer.OutlineView
 		protected override void SelectOnly(DragTreeViewItem item)
 		{
 			base.SelectOnly(item);
-			
-			var node = item.DataContext as IOutlineNode;
 
-			if (node.DesignItem != null) {
+			if (item.DataContext is IOutlineNode node && node.DesignItem != null) {
 				var surface = node.DesignItem.View.TryFindParent<DesignSurface>();
 				if (surface != null)
 					surface.ScrollIntoView(node.DesignItem);


### PR DESCRIPTION
Fixed a NullReferenceException caused by handling a left mouse click on a treenode that was already disconnected and replaced. This happens when an attribute of an element was changed and directly after that a childnode was clicked in the treeview. The node that was changed will be saved first and all childs will be removed and replaced by updated ones. After that, the mouse click on the removed child will still be executed, but that child is no IOutLineNode anymore and that causes the NullReferenceException.