### PR TITLE
Add SpecialInitializeComponent() to ColorPicker

### DIFF
--- a/WpfDesign.Designer/Project/Controls/ColorPicker.xaml.cs
+++ b/WpfDesign.Designer/Project/Controls/ColorPicker.xaml.cs
@@ -16,6 +16,8 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using ICSharpCode.WpfDesign.Designer.themes;
+using System;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -28,7 +30,22 @@ namespace ICSharpCode.WpfDesign.Designer.Controls
 	{
 		public ColorPicker()
 		{
-			InitializeComponent();
+			SpecialInitializeComponent();
+		}
+
+		/// <summary>
+		/// Fixes InitializeComponent with multiple Versions of same Assembly loaded
+		/// </summary>
+		public void SpecialInitializeComponent()
+		{
+			if (!this._contentLoaded)
+			{
+				this._contentLoaded = true;
+				Uri resourceLocator = new Uri(VersionedAssemblyResourceDictionary.GetXamlNameForType(this.GetType()), UriKind.Relative);
+				Application.LoadComponent(this, resourceLocator);
+			}
+
+			this.InitializeComponent();
 		}
 
 		public static readonly DependencyProperty ColorProperty =

--- a/WpfDesign.Designer/Tests/WpfDesign.Tests.csproj
+++ b/WpfDesign.Designer/Tests/WpfDesign.Tests.csproj
@@ -7,8 +7,8 @@
 	<AssemblyName>ICSharpCode.WpfDesign.Tests</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.2.0" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="RhinoMocks" Version="3.6.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fix issue https://github.com/icsharpcode/WpfDesigner/issues/109:
- Added SpecialInitializeComponent() to ColorPicker class
- Updated TestAdapter for NUnit to avoid problem with execute tests on machine with .Net 7+:
  - NUnit 3.13.2 -> 3.14.0
  - NUnit3TestAdapter 4.2.0 -> 4.5.0