### PR TITLE
Fix so that BorderForMouseOver of Line control is displayed at correct position

### DIFF
--- a/WpfDesign.Designer/Project/Extensions/BorderForMouseOver.cs
+++ b/WpfDesign.Designer/Project/Extensions/BorderForMouseOver.cs
@@ -16,7 +16,6 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
-using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;

--- a/WpfDesign.Designer/Project/Extensions/BorderForMouseOver.cs
+++ b/WpfDesign.Designer/Project/Extensions/BorderForMouseOver.cs
@@ -16,10 +16,11 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 // DEALINGS IN THE SOFTWARE.
 
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
-
+using System.Windows.Shapes;
 using ICSharpCode.WpfDesign.Adorners;
 using ICSharpCode.WpfDesign.Extensions;
 
@@ -31,18 +32,33 @@ namespace ICSharpCode.WpfDesign.Designer.Extensions
 	public class BorderForMouseOver : AdornerProvider
 	{
 		readonly AdornerPanel adornerPanel;
+		readonly Border border = new Border();
 
 		public BorderForMouseOver()
 		{
 			adornerPanel = new AdornerPanel();
 			adornerPanel.Order = AdornerOrder.Background;
 			this.Adorners.Add(adornerPanel);
-			var border = new Border();
 			border.BorderThickness = new Thickness(1);
 			border.BorderBrush = Brushes.DodgerBlue;
 			border.Margin = new Thickness(-2);
 			AdornerPanel.SetPlacement(border, AdornerPlacement.FillContent);
 			adornerPanel.Children.Add(border);
+		}
+
+		protected override void OnInitialized()
+		{
+			base.OnInitialized();
+
+			if (ExtendedItem.Component is Line line)
+			{
+				// To display border of Line in correct position.
+				border.Margin = new Thickness
+				{
+					Left = line.X2 < 0 ? line.X2 : 0,
+					Top = line.Y2 < 0 ? line.Y2 : 0
+				};
+			}
 		}
 	}
 }


### PR DESCRIPTION
Workaround for #115 